### PR TITLE
Add slicer-notebook image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER = docker
 ORG = slicer
 
 # Images
-ALL_IMAGES = slicer-base slicer-build slicer-dependencies slicer-test
+ALL_IMAGES = slicer-base slicer-build slicer-dependencies slicer-notebook slicer-test
 
 #
 # Name of images: The name is expected to have the following form: imagename[_imagetag]

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,12 @@ Docker images for 3D Slicer
 Images
 ------
 
+.. |slicer-notebook-images| image:: https://images.microbadger.com/badges/image/slicer/slicer-notebook.svg
+  :target: https://microbadger.com/images/slicer/slicer-notebook
+
+slicer/slicer-notebook
+  |slicer-notebook-images| Ready-to-run Docker images containing Slicer and Jupyter.
+
 .. |slicer-base-images| image:: https://images.microbadger.com/badges/image/slicer/slicer-base.svg
   :target: https://microbadger.com/images/slicer/slicer-base
 

--- a/slicer-notebook/.slicerrc.py
+++ b/slicer-notebook/.slicerrc.py
@@ -1,0 +1,2 @@
+# Set application window size to fill the screen by default
+slicer.util.mainWindow().size = qt.QSize(1280,1024)

--- a/slicer-notebook/Dockerfile
+++ b/slicer-notebook/Dockerfile
@@ -49,6 +49,8 @@ RUN apt-get install -q -y \
 # install jupyter
 RUN pip3 install jupyter
 
+# install ipython widgets required for SlicerNotebookLib
+RUN pip3 install ipywidgets ipycanvas ipyevents
 
 ################################################################################
 # set up user
@@ -65,11 +67,17 @@ WORKDIR ${HOME}
 
 ################################################################################
 # Download and unpack Slicer
-#RUN curl -OJL "http://slicer.kitware.com/midas3/download?bitstream=887990" && \
-#    tar xzf Slicer-4.10.0-linux-amd64.tar.gz
 
-ARG SLICER_ARCHIVE=Slicer-4.11.0-2020-05-11-linux-amd64
-ADD $SLICER_ARCHIVE.tar.gz ${HOME}/
+ARG SLICER_ARCHIVE=Slicer-4.11.0-2020-05-14-linux-amd64
+ARG SLICER_DOWNLOAD_URL=http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&name=Slicer-4.11.0-2020-05-14-linux-amd64.tar.gz&checksum=971ddac26fe28a962e6838bab0f455d2
+
+# Use local package:
+#ADD $SLICER_ARCHIVE.tar.gz ${HOME}/
+
+# Download package:
+RUN curl -OJL "$SLICER_DOWNLOAD_URL" && \
+    tar xzf $SLICER_ARCHIVE.tar.gz && \
+    rm $SLICER_ARCHIVE.tar.gz
 
 ################################################################################
 # these go after installs to avoid trivial invalidation
@@ -84,23 +92,28 @@ COPY xorg.conf .
 RUN chown ${NB_USER} ${HOME} ${HOME}/Slicer-*
 
 ################################################################################
-# trying nbnovnc
-RUN apt-get -y -q install \
-  git \
-  novnc \
-  sudo \
-  supervisor \
-  tightvncserver \
-  xinit \
-  websockify
+# Set up remote desktop access
+RUN apt-get -y -q install git
+
+RUN pip3 install --upgrade websockify
+
+# Websockify needs rebind.so but for some reason it is not built and
+# installed automatically, so we do it manually here
+RUN apt-get -y install build-essential
+RUN mkdir src && \
+    cd src && \
+    git clone https://github.com/novnc/websockify websockify && \
+    cd websockify  && \
+    make && \
+    cp rebind.so /usr/local/lib/ && \
+    cd .. && \
+    rm websockify -rf
+# TODO: remove build-essential?
 
 RUN pip3 install -e \
-  git+https://github.com/ryanlovett/nbnovnc#egg=nbnovnc \
+  git+https://github.com/lassoan/jupyter-desktop-server#egg=jupyter-desktop-server \
   git+https://github.com/jupyterhub/jupyter-server-proxy#egg=jupyter-server-proxy
 
-RUN jupyter serverextension enable  --py nbnovnc && \
-    jupyter nbextension     install --py nbnovnc && \
-    jupyter nbextension     enable  --py nbnovnc
 
 ################################################################################
 # Need to run Slicer as non-root because
@@ -113,10 +126,18 @@ ENV XDG_RUNTIME_DIR=/tmp/runtime-sliceruser
 
 ################################################################################
 # Set up SlicerJupyter
-COPY 29054-linux-amd64-SlicerJupyter-git08d133c-2020-05-11.tar.gz .
+
+ARG SLICER_JUPYTER_ARCHIVE=29057-linux-amd64-SlicerJupyter-git6993275-2020-05-14.tar.gz
+ARG SLICER_JUPYTER_DOWNLOAD_URL=http://slicer.kitware.com/midas3/api/rest?method=midas.bitstream.download&name=29057-linux-amd64-SlicerJupyter-git6993275-2020-05-14.tar.gz&checksum=2e06dc51ecebd9345cea80953b5a9d5b
+
+RUN curl -OJL "$SLICER_JUPYTER_DOWNLOAD_URL"
+#COPY $SLICER_JUPYTER_ARCHIVE .
+
 COPY start-xorg.sh .
 COPY install.sh .
 RUN ./install.sh ${HOME}/$SLICER_ARCHIVE/Slicer
+
+RUN rm $SLICER_JUPYTER_ARCHIVE
 
 ################################################################################
 EXPOSE $VNCPORT $JUPYTERPORT
@@ -124,6 +145,11 @@ COPY run.sh .
 ENTRYPOINT ["/home/sliceruser/run.sh"]
 
 CMD ["sh", "-c", "jupyter notebook --port=$JUPYTERPORT --ip=0.0.0.0 --no-browser"]
+
+################################################################################
+# Install Slicer application startup script
+
+COPY .slicerrc.py .
 
 ################################################################################
 # Build-time metadata as defined at http://label-schema.org

--- a/slicer-notebook/Dockerfile
+++ b/slicer-notebook/Dockerfile
@@ -1,0 +1,138 @@
+FROM debian:bullseye-20200422-slim
+
+################################################################################
+# Prevent apt-get from prompting for keyboard choice
+#  https://superuser.com/questions/1356914/how-to-install-xserver-xorg-in-unattended-mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+################################################################################
+# Remove documentation to save hard drive space
+#  https://askubuntu.com/questions/129566/remove-documentation-to-save-hard-drive-space
+COPY etc/dpkg/dpkg.cfg.d/01_nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
+
+################################################################################
+# - update apt, set up certs, run netselect to get fast mirror
+# - reduce apt gravity
+# - and disable caching
+#   from https://blog.sleeplessbeastie.eu/2017/10/02/how-to-disable-the-apt-cache/
+RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' >> /etc/apt/apt.conf && \
+    echo 'Dir::Cache::pkgcache "";\nDir::Cache::srcpkgcache "";' | tee /etc/apt/apt.conf.d/00_disable-cache-files && \
+    apt-get update -q -y
+
+################################################################################
+# get packages
+# - update
+# - install things
+#   - basic  tools
+#   - slicer dependencies
+#   - awesome window manager
+RUN apt-get install -q -y \
+ vim net-tools curl \
+ libgl1-mesa-glx \
+ xserver-xorg-video-dummy \
+ libxrender1 \
+ libpulse0 \
+ libpulse-mainloop-glib0  \
+ libnss3  \
+ libxcomposite1 \
+ libxcursor1 \
+ libfontconfig1 \
+ libxrandr2 \
+ libasound2 \
+ libglu1 \
+ x11vnc \
+ awesome \
+ python3 python3-pip python3-setuptools \
+ jq
+
+################################################################################
+# install jupyter
+RUN pip3 install jupyter
+
+
+################################################################################
+# set up user
+ENV NB_USER sliceruser
+ENV NB_UID 1000
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+            --gecos "Default user" \
+            --uid ${NB_UID} \
+            ${NB_USER}
+
+WORKDIR ${HOME}
+
+################################################################################
+# Download and unpack Slicer
+#RUN curl -OJL "http://slicer.kitware.com/midas3/download?bitstream=887990" && \
+#    tar xzf Slicer-4.10.0-linux-amd64.tar.gz
+
+ARG SLICER_ARCHIVE=Slicer-4.11.0-2020-05-11-linux-amd64
+ADD $SLICER_ARCHIVE.tar.gz ${HOME}/
+
+################################################################################
+# these go after installs to avoid trivial invalidation
+ENV VNCPORT=49053
+ENV JUPYTERPORT=8888
+ENV DISPLAY=:10
+
+COPY xorg.conf .
+
+################################################################################
+# mybinder requirement
+RUN chown ${NB_USER} ${HOME} ${HOME}/Slicer-*
+
+################################################################################
+# trying nbnovnc
+RUN apt-get -y -q install \
+  git \
+  novnc \
+  sudo \
+  supervisor \
+  tightvncserver \
+  xinit \
+  websockify
+
+RUN pip3 install -e \
+  git+https://github.com/ryanlovett/nbnovnc#egg=nbnovnc \
+  git+https://github.com/jupyterhub/jupyter-server-proxy#egg=jupyter-server-proxy
+
+RUN jupyter serverextension enable  --py nbnovnc && \
+    jupyter nbextension     install --py nbnovnc && \
+    jupyter nbextension     enable  --py nbnovnc
+
+################################################################################
+# Need to run Slicer as non-root because
+# - mybinder requirement
+# - chrome sandbox inside QtWebEngine does not support root.
+USER ${NB_USER}
+
+RUN mkdir /tmp/runtime-sliceruser
+ENV XDG_RUNTIME_DIR=/tmp/runtime-sliceruser
+
+################################################################################
+# Set up SlicerJupyter
+COPY 29054-linux-amd64-SlicerJupyter-git08d133c-2020-05-11.tar.gz .
+COPY start-xorg.sh .
+COPY install.sh .
+RUN ./install.sh ${HOME}/$SLICER_ARCHIVE/Slicer
+
+################################################################################
+EXPOSE $VNCPORT $JUPYTERPORT
+COPY run.sh .
+ENTRYPOINT ["/home/sliceruser/run.sh"]
+
+CMD ["sh", "-c", "jupyter notebook --port=$JUPYTERPORT --ip=0.0.0.0 --no-browser"]
+
+################################################################################
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/slicer-notebook/docker_launch.sh
+++ b/slicer-notebook/docker_launch.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker run -p 8888:8888 -p49053:49053 -v "$PWD":/home/sliceruser/work --rm -ti slicer/slicer-notebook

--- a/slicer-notebook/etc/dpkg/dpkg.cfg.d/01_nodoc
+++ b/slicer-notebook/etc/dpkg/dpkg.cfg.d/01_nodoc
@@ -1,0 +1,11 @@
+# /etc/dpkg/dpkg.cfg.d/01_nodoc
+
+# Delete locales
+path-exclude=/usr/share/locale/*
+
+# Delete man pages
+path-exclude=/usr/share/man/*
+
+# Delete docs
+path-exclude=/usr/share/doc/*
+path-include=/usr/share/doc/*/copyright

--- a/slicer-notebook/install.sh
+++ b/slicer-notebook/install.sh
@@ -53,6 +53,19 @@ $slicer_executable \
   --disable-scripted-loadable-modules \
   -c "slicer.modules.jupyterkernel.installSlicerKernel('/usr/local/bin/')"
 
+# Fix ImportError: ...python3.6/site-packages/PIL/_imaging.cpython-36m-x86_64-linux-gnu.so: ELF load command address/offset not properly aligned
+# by forcing reinstalling pillow (a properly maintained fork of PIL).
+$slicer_executable \
+  --disable-cli-modules \
+  --disable-scripted-loadable-modules \
+  -c "pip_install('--upgrade pillow --force-reinstall'); pip_install('ipywidgets pandas ipyevents ipycanvas')"
+
+# Install packages needed by SlicerNotebookLib
+$slicer_executable \
+  --disable-cli-modules \
+  --disable-scripted-loadable-modules \
+  -c "pip_install('ipywidgets pandas ipyevents ipycanvas')"
+
 ################################################################################
 # Shutdown headless environment
 kill -9 $XORG_PID

--- a/slicer-notebook/install.sh
+++ b/slicer-notebook/install.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+set +x
+
+script_dir=$(cd $(dirname $0) || exit 1; pwd)
+PROG=$(basename $0)
+
+err() { echo -e >&2 ERROR: $@\\n; }
+die() { err $@; exit 1; }
+
+if [ "$#" -ne 1 ]; then
+  die "Usage: $PROG /path/to/Slicer-X.Y.Z-linux-amd64/Slicer"
+fi
+
+slicer_executable=$1
+
+################################################################################
+# Set up headless environment
+source $script_dir/start-xorg.sh
+echo "XORG_PID [$XORG_PID]"
+
+################################################################################
+# Get slicer revision
+slicer_revision=$($slicer_executable --disable-modules -c "print(slicer.app.revision)" | head -n1)
+echo "slicer_revision [$slicer_revision]"
+
+# Lookup extension_id associated with SlicerJupyter
+#extension_id=$(curl -s -X GET \
+#  "https://slicer.kitware.com/midas3/api/json?method=midas.slicerpackages.extension.list&os=linux&arch=amd64&slicer_revision=$slicer_revision&search=SlicerJupyter" \
+#  -H "accept: application/json" | jq ".data[0].extension_id")
+#echo "extension_id [$extension_id]"
+
+# Download and install the extension install
+#$slicer_executable \
+#  --disable-loadable-modules \
+#  --disable-cli-modules \
+#  --disable-scripted-loadable-modules \
+#  -c "slicer.app.extensionsManagerModel().downloadAndInstallExtension('$extension_id')"
+
+# Install the extension install
+extension_archive=$(ls -1 $PWD/$slicer_revision-linux-amd64-SlicerJupyter-*)
+echo "extension_archive [$extension_archive]"
+$slicer_executable \
+  --disable-loadable-modules \
+  --disable-cli-modules \
+  --disable-scripted-loadable-modules \
+  -c "slicer.app.extensionsManagerModel().installExtension('$extension_archive')"
+
+# Install kernel
+$slicer_executable \
+  --disable-cli-modules \
+  --disable-scripted-loadable-modules \
+  -c "slicer.modules.jupyterkernel.installSlicerKernel('/usr/local/bin/')"
+
+################################################################################
+# Shutdown headless environment
+kill -9 $XORG_PID
+rm /tmp/.X10-lock

--- a/slicer-notebook/run.sh
+++ b/slicer-notebook/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+script_dir=$(cd $(dirname $0) || exit 1; pwd)
+
+################################################################################
+# Set up headless environment
+source $script_dir/start-xorg.sh
+
+#/usr/bin/x11vnc -forever -rfbport $VNCPORT -display :10 -shared -bg -auth none -nopw
+#sleep 1
+
+################################################################################
+# start window manager
+awesome &
+
+################################################################################
+# this needs to be last
+exec "$@"

--- a/slicer-notebook/run.sh
+++ b/slicer-notebook/run.sh
@@ -13,7 +13,11 @@ source $script_dir/start-xorg.sh
 
 ################################################################################
 # start window manager
-awesome &
+
+# Do not start a window manager to make the remote desktop look more like a simple
+# remote view rather than a complete remote computer.
+#awesome &
+
 
 ################################################################################
 # this needs to be last

--- a/slicer-notebook/start-xorg.sh
+++ b/slicer-notebook/start-xorg.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+set +x
+
+Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile ./10.log -config $HOME/xorg.conf $DISPLAY &
+
+# grab the process id in order to control it later
+export XORG_PID=$!
+
+# give bg X time to start
+sleep 2

--- a/slicer-notebook/xorg.conf
+++ b/slicer-notebook/xorg.conf
@@ -1,0 +1,85 @@
+# This xorg configuration file is meant to be used by xpra
+# to start a dummy X11 server.
+# For details, please see:
+# https://xpra.org/Xdummy.html
+
+Section "ServerFlags"
+  Option "DontVTSwitch" "true"
+  Option "AllowMouseOpenFail" "true"
+  Option "PciForceNone" "true"
+  Option "AutoEnableDevices" "false"
+  Option "AutoAddDevices" "false"
+EndSection
+
+Section "InputDevice"
+  Identifier "dummy_mouse"
+  Option "CorePointer" "true"
+  Driver "void"
+EndSection
+
+Section "InputDevice"
+  Identifier "dummy_keyboard"
+  Option "CoreKeyboard" "true"
+  Driver "void"
+EndSection
+
+Section "Device"
+  Identifier "dummy_videocard"
+  Driver "dummy"
+  Option "ConstantDPI" "true"
+  #VideoRam 4096000
+  #VideoRam 256000
+  VideoRam 192000
+EndSection
+
+Section "Monitor"
+  Identifier "dummy_monitor"
+  HorizSync   5.0 - 1000.0
+  VertRefresh 5.0 - 200.0
+  #This can be used to get a specific DPI, but only for the default resolution:
+  #DisplaySize 508 317
+  #NOTE: the highest modes will not work without increasing the VideoRam
+  # for the dummy video card.
+  Modeline "1920x1440" 69.47 1920 1960 2152 2384 1440 1441 1444 1457
+  Modeline "1920x1200" 26.28 1920 1952 2048 2080 1200 1229 1231 1261
+  Modeline "1920x1080" 23.53 1920 1952 2040 2072 1080 1106 1108 1135
+  Modeline "1680x1050" 20.08 1680 1712 1784 1816 1050 1075 1077 1103
+  Modeline "1600x1200" 22.04 1600 1632 1712 1744 1200 1229 1231 1261
+  Modeline "1600x900" 33.92 1600 1632 1760 1792 900 921 924 946
+  Modeline "1440x900" 30.66 1440 1472 1584 1616 900 921 924 946
+  ModeLine "1366x768" 72.00 1366 1414 1446 1494  768 771 777 803
+  Modeline "1280x1024" 31.50 1280 1312 1424 1456 1024 1048 1052 1076
+  Modeline "1280x800" 24.15 1280 1312 1400 1432 800 819 822 841
+  Modeline "1280x768" 23.11 1280 1312 1392 1424 768 786 789 807
+  Modeline "1360x768" 24.49 1360 1392 1480 1512 768 786 789 807
+  Modeline "1024x768" 18.71 1024 1056 1120 1152 768 786 789 807
+  Modeline "768x1024" 19.50 768 800 872 904 1024 1048 1052 1076
+
+
+  Modeline "1280x800" 24.15 1280 1312 1400 1432 800 819 822 841
+  Option          "PreferredMode" "1280x1024"
+EndSection
+
+Section "Screen"
+  Identifier "dummy_screen"
+  Device "dummy_videocard"
+  Monitor "dummy_monitor"
+  DefaultDepth 24
+  SubSection "Display"
+    Viewport 0 0
+    Depth 24
+    #Modes "32768x32768" "32768x16384" "16384x8192" "8192x4096" "5120x3200" "3840x2880" "3840x2560" "3840x2048" "2048x2048" "2560x1600" "1920x1440" "1920x1200" "1920x1080" "1600x1200" "1680x1050" "1600x900" "1400x1050" "1440x900" "1280x1024" "1366x768" "1280x800" "1024x768" "1024x600" "800x600" "320x200"
+    Modes "1400x1050" "1440x900" "1280x1024" "1366x768" "1280x800" "1024x768" "1024x600" "800x600" "320x200"
+    #Virtual 32000 32000
+    #Virtual 16384 8192
+    Virtual 1280 1024
+    #Virtual 5120 3200
+  EndSubSection
+EndSection
+
+Section "ServerLayout"
+  Identifier   "dummy_layout"
+  Screen       "dummy_screen"
+  InputDevice  "dummy_mouse"
+  InputDevice  "dummy_keyboard"
+EndSection


### PR DESCRIPTION
This work was adapted from https://github.com/ihnorton/dockerfiles/tree/master/slicer2binder

Todo: 
* [ ] in addition of `slicer/slicer-notebook:latest`, we should have a proper tag of the form `slicer/slicer-notebook:YYYYMMDD-SHA{7}` like what is done in https://github.com/dockcross/dockcross
* [ ] add script for updating reference in [slicer-notebook/Dockerfile](https://github.com/Slicer/SlicerDocker/blob/0a89b3c071d2771d4802d7b4ce956428210607c5/slicer-notebook/Dockerfile#L71)
* [x] add `slicer-notebook/README.md`
* [x] update to use [jupyter-desktop-server](https://github.com/yuvipanda/jupyter-desktop-server) instead of obsolete [nbnovnc](https://github.com/ryanlovett/nbnovnc)
* [ ] optimize image size