### PR TITLE
COMP: slicer-base: Attempt to fix "g++: internal compiler error"

### DIFF
--- a/slicer-base/Dockerfile
+++ b/slicer-base/Dockerfile
@@ -19,6 +19,9 @@ RUN \
   cmake \
     -G Ninja \
     -DCMAKE_BUILD_TYPE:STRING=Release \
+    -DCMAKE_JOB_POOLS:STRING="compile=16;link=8" \
+    -DCMAKE_JOB_POOL_COMPILE:STRING=compile \
+    -DCMAKE_JOB_POOL_LINK:STRING=link \
     -DQt5_DIR:PATH=${Qt5_DIR} \
     -DSlicer_BUILD_ITKPython:BOOL=OFF \
     -DSlicer_INSTALL_ITKPython:BOOL=OFF \


### PR DESCRIPTION
This commit attempts to fix "g++: internal compiler error" likely
introduced by Slicer/Slicer@b1c235939 (COMP: Update ITK to post-5.3rc03
and SimpleITK to post-2.2rc2) now requiring more memory to compile and/or
link.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71671

By specifying link and compile job pool size similar to what is
used for the nightly build also done within a docker image, this commit
should address the issue.

See https://github.com/Slicer/DashboardScripts/commit/ed28012db8f761bb9247dfae2c61a3e2e097a4f2
and https://discourse.slicer.org/t/ninja-build-using-too-many-cores/2304/3

Error:

```
  FAILED: Code/Common/src/CMakeFiles/SimpleITKCommon.dir/sitkImageExplicit.cxx.o
  /opt/rh/devtoolset-7/root/usr/bin/g++  -I/usr/src/Slicer-build/ITK-build/Modules/Core/Common -I/usr/src/Slicer-build/ITK/Modules/Core/Common/include -I/usr/src/Slicer-build/ITK-build/Modules/ThirdParty/Eigen3/src -I/usr/src/Slicer-build/ITK/Modules/ThirdParty/VNL/src/vxl/core -I/usr/src/Slicer-build/ITK-build/Modules/ThirdParty/VNL/src/vxl/v3p/netlib -I/usr/src/Slicer-build/ITK-build/Modules/ThirdParty/VNL/src/vxl/vcl -I/usr/src/Slicer-build/ITK-build/Modules/ThirdParty/VNL/src/vxl/core -I/usr/src/Slicer-build/ITK/Modules/Filtering/ImageCompose/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/ImageFilterBase/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/ImageIntensity/include -I/usr/src/Slicer-build/ITK/Modules/Core/ImageAdaptors/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/ImageGrid/include -I/usr/src/Slicer-build/ITK/Modules/Core/ImageFunction/include -I/usr/src/Slicer-build/ITK/Modules/Numerics/Statistics/include -I/usr/src/Slicer-build/ITK-build/Modules/ThirdParty/Netlib -I/usr/src/Slicer-build/ITK/Modules/Core/Transform/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/ImageStatistics/include -I/usr/src/Slicer-build/ITK/Modules/Core/SpatialObjects/include -I/usr/src/Slicer-build/ITK-build/Modules/ThirdParty/MetaIO/src/MetaIO/src -I/usr/src/Slicer-build/ITK/Modules/ThirdParty/MetaIO/src/MetaIO/src -I/usr/src/Slicer-build/ITK-build/Modules/ThirdParty/ZLIB/src -I/usr/src/Slicer-build/zlib-install/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/Path/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/LabelMap/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/ImageLabel/include -I/usr/src/Slicer-build/ITK/Modules/IO/TransformBase/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/DisplacementField/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/Smoothing/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/Convolution/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/FFT/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/Thresholding/include -I/usr/src/Slicer-build/ITK/Modules/Filtering/ImageSources/include -I/usr/src/Slicer-build/ITK/Modules/IO/TransformFactory/include -I/usr/src/Slicer-build/SimpleITK/Code/Common/include -I/usr/src/Slicer-build/SimpleITK-build/SimpleITK-build/Code/Common/include -isystem /usr/src/Slicer-build/ITK/Modules/ThirdParty/Eigen3/src/itkeigen/.. -isystem /usr/src/Slicer-build/ITK-build/Modules/ThirdParty/KWSys/src -isystem /usr/src/Slicer-build/ITK/Modules/ThirdParty/VNL/src/vxl/v3p/netlib -isystem /usr/src/Slicer-build/ITK/Modules/ThirdParty/VNL/src/vxl/vcl -isystem /usr/src/Slicer-build/ITK/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo -isystem /usr/src/Slicer-build/ITK/Modules/ThirdParty/VNL/src/vxl/core/vnl -isystem /usr/src/Slicer-build/ITK-build/Modules/ThirdParty/VNL/src/vxl/core/vnl -O3 -DNDEBUG -fPIC -fvisibility=default -fvisibility-inlines-hidden -Wall -Wno-long-long -Wno-unused-local-typedefs -Wno-strict-overflow -Wextra -Wformat=2 -Wno-format-nonliteral -Wunused -Wpointer-arith -Winvalid-pch -Wcast-align -Wdisabled-optimization -Woverloaded-virtual -Wshadow -Wwrite-strings -Wstrict-null-sentinel -Wno-invalid-offsetof -std=c++14 -MD -MT Code/Common/src/CMakeFiles/SimpleITKCommon.dir/sitkImageExplicit.cxx.o -MF Code/Common/src/CMakeFiles/SimpleITKCommon.dir/sitkImageExplicit.cxx.o.d -o Code/Common/src/CMakeFiles/SimpleITKCommon.dir/sitkImageExplicit.cxx.o -c /usr/src/Slicer-build/SimpleITK/Code/Common/src/sitkImageExplicit.cxx
  g++: internal compiler error: Killed (program cc1plus)
  Please submit a full bug report,
  with preprocessed source if appropriate.
  See <http://bugzilla.redhat.com/bugzilla> for instructions.
```